### PR TITLE
Refactor goal specification, clean up utils.py defaults, upgrade compatibility to newest brax/mjx

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,11 +5,9 @@ dependencies:
   - python=3.10
   - jax=0.4.25
   - scipy==1.12.0
-  - mujoco==3.1.2
   - scikit-image==0.22.0
   - flax=0.8.3
   - chex=0.1.86
-  - brax==0.10.0
   - dm-haiku==0.0.11
   - six=1.16.0
   - statsmodels==0.14.1
@@ -21,7 +19,9 @@ dependencies:
   - pip
   - pip:
     - nvidia-cudnn-cu12==8.9.7.29
-    - mujoco-mjx==3.1.2
+    - brax==0.10.5
+    - mujoco==3.2.3
+    - mujoco-mjx==3.2.3
     - stack-data==0.6.3
     - jaxlib==0.4.25+cuda12.cudnn89
     - -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html

--- a/envs/ant.py
+++ b/envs/ant.py
@@ -23,7 +23,7 @@ class Ant(PipelineEnv):
         healthy_z_range=(0.2, 1.0),
         contact_force_range=(-1.0, 1.0),
         reset_noise_scale=0.1,
-        exclude_current_positions_from_observation=True,
+        exclude_current_positions_from_observation=False,
         backend="generalized",
         **kwargs,
     ):
@@ -33,7 +33,7 @@ class Ant(PipelineEnv):
         n_frames = 5
 
         if backend in ["spring", "positional"]:
-            sys = sys.replace(dt=0.005)
+            sys = sys.tree_replace({"opt.timestep": 0.005})
             n_frames = 10
 
         if backend == "mjx":
@@ -69,6 +69,9 @@ class Ant(PipelineEnv):
         self._exclude_current_positions_from_observation = (
             exclude_current_positions_from_observation
         )
+        
+        self.obs_dim = 29
+        self.goal_indices = jp.array([0, 1])
 
         if self._use_contact_forces:
             raise NotImplementedError("use_contact_forces not implemented.")

--- a/envs/ant_ball.py
+++ b/envs/ant_ball.py
@@ -23,7 +23,7 @@ class AntBall(PipelineEnv):
         healthy_z_range=(0.2, 1.0),
         contact_force_range=(-1.0, 1.0),
         reset_noise_scale=0.1,
-        exclude_current_positions_from_observation=True,
+        exclude_current_positions_from_observation=False,
         backend="generalized",
         **kwargs,
     ):
@@ -33,7 +33,7 @@ class AntBall(PipelineEnv):
         n_frames = 5
 
         if backend in ["spring", "positional"]:
-            sys = sys.replace(dt=0.005)
+            sys = sys.tree_replace({"opt.timestep": 0.005})
             n_frames = 10
 
         if backend == "mjx":
@@ -71,6 +71,9 @@ class AntBall(PipelineEnv):
         )
         self._object_idx = self.sys.link_names.index('object')
 
+        self.obs_dim = 31
+        self.goal_indices = jp.array([28, 29])
+        
         if self._use_contact_forces:
             raise NotImplementedError("use_contact_forces not implemented.")
 

--- a/envs/ant_maze.py
+++ b/envs/ant_maze.py
@@ -147,7 +147,7 @@ class AntMaze(PipelineEnv):
         healthy_z_range=(0.2, 1.0),
         contact_force_range=(-1.0, 1.0),
         reset_noise_scale=0.1,
-        exclude_current_positions_from_observation=True,
+        exclude_current_positions_from_observation=False,
         backend="generalized",
         maze_layout_name="u_maze",
         maze_size_scaling=4.0,
@@ -161,7 +161,7 @@ class AntMaze(PipelineEnv):
         n_frames = 5
 
         if backend in ["spring", "positional"]:
-            sys = sys.replace(dt=0.005)
+            sys = sys.tree_replace({"opt.timestep": 0.005})
             n_frames = 10
 
         if backend == "mjx":
@@ -197,6 +197,9 @@ class AntMaze(PipelineEnv):
         self._exclude_current_positions_from_observation = (
             exclude_current_positions_from_observation
         )
+        
+        self.obs_dim = 29
+        self.goal_indices = jp.array([0, 1])
 
         if self._use_contact_forces:
             raise NotImplementedError("use_contact_forces not implemented.")

--- a/envs/ant_push.py
+++ b/envs/ant_push.py
@@ -24,7 +24,7 @@ class AntPush(PipelineEnv):
         healthy_z_range=(0.2, 1.0),
         contact_force_range=(-1.0, 1.0),
         reset_noise_scale=0.1,
-        exclude_current_positions_from_observation=True,
+        exclude_current_positions_from_observation=False,
         backend="mjx",
         **kwargs,
     ):
@@ -59,6 +59,9 @@ class AntPush(PipelineEnv):
             exclude_current_positions_from_observation
         )
         self._object_idx = self.sys.link_names.index('movable')
+        
+        self.obs_dim = 31
+        self.goal_indices = jp.array([0, 1])
 
         if self._use_contact_forces:
             raise NotImplementedError("use_contact_forces not implemented.")

--- a/envs/debug_env.py
+++ b/envs/debug_env.py
@@ -18,7 +18,7 @@ class Debug(PipelineEnv):
         n_frames = 2
 
         if backend in ["spring", "positional"]:
-            sys = sys.replace(dt=0.005)
+            sys = sys.tree_replace({"opt.timestep": 0.005})
             sys = sys.replace(
                 actuator=sys.actuator.replace(gear=jp.array([25.0, 25.0]))
             )
@@ -27,6 +27,9 @@ class Debug(PipelineEnv):
         kwargs["n_frames"] = kwargs.get("n_frames", n_frames)
 
         super().__init__(sys=sys, backend=backend, **kwargs)
+        
+        self.obs_dim = 3
+        self.goal_indices = jp.array([1, 2])
 
     def reset(self, rng: jax.Array) -> State:
         rng, rng1, rng2, rng3 = jax.random.split(rng, 4)

--- a/envs/half_cheetah.py
+++ b/envs/half_cheetah.py
@@ -16,8 +16,8 @@ class Halfcheetah(PipelineEnv):
         forward_reward_weight=1.0,
         ctrl_cost_weight=0.1,
         reset_noise_scale=0.1,
-        exclude_current_positions_from_observation=True,
-        backend="generalized",
+        exclude_current_positions_from_observation=False,
+        backend="mjx",
         **kwargs
     ):
         path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'assets', "half_cheetah.xml")
@@ -26,7 +26,7 @@ class Halfcheetah(PipelineEnv):
         n_frames = 5
 
         if backend in ["spring", "positional"]:
-            sys = sys.replace(dt=0.003125)
+            sys = sys.tree_replace({"opt.timestep": 0.003125})
             n_frames = 16
             gear = jp.array([120, 90, 60, 120, 100, 100])
             sys = sys.replace(actuator=sys.actuator.replace(gear=gear))
@@ -41,6 +41,9 @@ class Halfcheetah(PipelineEnv):
         self._exclude_current_positions_from_observation = (
             exclude_current_positions_from_observation
         )
+        
+        self.obs_dim = 18
+        self.goal_indices = jp.array([0])
 
     def reset(self, rng: jax.Array) -> State:
         """Resets the environment to an initial state."""

--- a/envs/humanoid.py
+++ b/envs/humanoid.py
@@ -62,6 +62,9 @@ class Humanoid(PipelineEnv):
         exclude_current_positions_from_observation
     )
     self._target_ind = self.sys.link_names.index('target')
+    
+    self.obs_dim = 268
+    self.goal_indices = jp.array([0, 1, 2])
 
   def reset(self, rng: jax.Array) -> State:
     """Resets the environment to an initial state."""

--- a/envs/pusher.py
+++ b/envs/pusher.py
@@ -18,7 +18,8 @@ class Pusher(PipelineEnv):
     n_frames = 5
 
     if backend in ['spring', 'positional']:
-      sys = sys.replace(dt=0.001)
+      sys = sys.tree_replace({"opt.timestep": 0.001})
+    
       sys = sys.replace(
           actuator=sys.actuator.replace(gear=jp.array([20.0] * sys.act_size()))
       )
@@ -34,6 +35,9 @@ class Pusher(PipelineEnv):
     self._object_idx = self.sys.link_names.index('object')
     self._goal_idx = self.sys.link_names.index('goal')
     self.kind = kind
+    
+    self.obs_dim = 20
+    self.goal_indices = jp.array([10, 11, 12])
 
   def reset(self, rng: jax.Array) -> State:
     qpos = self.sys.init_q
@@ -148,7 +152,7 @@ class PusherReacher(PipelineEnv):
     n_frames = 5
 
     if backend in ['spring', 'positional']:
-      sys = sys.replace(dt=0.001)
+      sys = sys.tree_replace({"opt.timestep": 0.001})
       sys = sys.replace(
           actuator=sys.actuator.replace(gear=jp.array([20.0] * sys.act_size()))
       )
@@ -163,6 +167,9 @@ class PusherReacher(PipelineEnv):
     self._tips_arm_idx = self.sys.link_names.index('r_wrist_flex_link')
     self._object_idx = self.sys.link_names.index('object')
     self._goal_idx = self.sys.link_names.index('goal')
+    
+    self.obs_dim = 17
+    self.goal_indices = jp.array([14, 15, 16])
 
   def reset(self, rng: jax.Array) -> State:
     qpos = self.sys.init_q

--- a/envs/reacher.py
+++ b/envs/reacher.py
@@ -18,7 +18,7 @@ class Reacher(PipelineEnv):
         n_frames = 2
 
         if backend in ["spring", "positional"]:
-            sys = sys.replace(dt=0.005)
+            sys = sys.tree_replace({"opt.timestep": 0.005})
             sys = sys.replace(
                 actuator=sys.actuator.replace(gear=jp.array([25.0, 25.0]))
             )
@@ -27,6 +27,9 @@ class Reacher(PipelineEnv):
         kwargs["n_frames"] = kwargs.get("n_frames", n_frames)
 
         super().__init__(sys=sys, backend=backend, **kwargs)
+        
+        self.obs_dim = 10
+        self.goal_indices = jp.array([4, 5, 6])
 
     def reset(self, rng: jax.Array) -> State:
         rng, rng1, rng2 = jax.random.split(rng, 3)

--- a/notebooks/visualize.ipynb
+++ b/notebooks/visualize.ipynb
@@ -72,7 +72,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "crl_networks = networks.make_crl_networks(config, obs_size, action_size)\n",
+    "crl_networks = networks.make_crl_networks(config, env, obs_size, action_size)\n",
     "\n",
     "inference_fn = networks.make_inference_fn(crl_networks)\n",
     "inference_fn = inference_fn(params[:2])\n",
@@ -130,7 +130,7 @@
     "raw_observations = np.array([state.obs for (state, _) in trajectories[TRAJECTORY_TO_DRAW]])\n",
     "actions = np.array([act for (_, act) in trajectories[TRAJECTORY_TO_DRAW]])\n",
     "\n",
-    "observations = raw_observations[:, :config.obs_dim]\n",
+    "observations = raw_observations[:, :env.obs_dim]\n",
     "\n",
     "encoded_sa = sa_encoder(jp.concatenate((observations, actions), axis = 1))\n",
     "\n",
@@ -166,7 +166,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,

--- a/scripts/train.sh
+++ b/scripts/train.sh
@@ -8,12 +8,12 @@
 eval "$(conda shell.bash hook)"
 conda activate contrastive_rl
 
-env=ant
+env=humanoid
 
-for seed in 1 2 3 4 5 ; do
+for seed in 1; do
   XLA_PYTHON_CLIENT_MEM_FRACTION=.95 MUJOCO_GL=egl CUDA_VISIBLE_DEVICES=0 python training.py \
-    --project_name test --group_name first_run --exp_name test --num_evals 50 \
-    --seed ${seed} --num_timesteps 10000000 --batch_size 256 --num_envs 512 \
+    --project_name test --group_name first_run --exp_name test --num_evals 10 \
+    --seed ${seed} --num_timesteps 1000000 --batch_size 256 --num_envs 512 \
     --discounting 0.99 --action_repeat 1 --env_name ${env} \
     --episode_length 1000 --unroll_length 62  --min_replay_size 1000 --max_replay_size 10000 \
     --contrastive_loss_fn infonce_backward --energy_fn l2 \

--- a/scripts/train.sh
+++ b/scripts/train.sh
@@ -8,12 +8,12 @@
 eval "$(conda shell.bash hook)"
 conda activate contrastive_rl
 
-env=humanoid
+env=Ant
 
-for seed in 1; do
+for seed in 1 2 3 4 5 ; do
   XLA_PYTHON_CLIENT_MEM_FRACTION=.95 MUJOCO_GL=egl CUDA_VISIBLE_DEVICES=0 python training.py \
-    --project_name test --group_name first_run --exp_name test --num_evals 10 \
-    --seed ${seed} --num_timesteps 1000000 --batch_size 256 --num_envs 512 \
+    --project_name test --group_name first_run --exp_name test --num_evals 50 \
+    --seed ${seed} --num_timesteps 10000000 --batch_size 256 --num_envs 512 \
     --discounting 0.99 --action_repeat 1 --env_name ${env} \
     --episode_length 1000 --unroll_length 62  --min_replay_size 1000 --max_replay_size 10000 \
     --contrastive_loss_fn infonce_backward --energy_fn l2 \

--- a/scripts/train.sh
+++ b/scripts/train.sh
@@ -8,7 +8,7 @@
 eval "$(conda shell.bash hook)"
 conda activate contrastive_rl
 
-env=Ant
+env=ant
 
 for seed in 1 2 3 4 5 ; do
   XLA_PYTHON_CLIENT_MEM_FRACTION=.95 MUJOCO_GL=egl CUDA_VISIBLE_DEVICES=0 python training.py \

--- a/src/losses.py
+++ b/src/losses.py
@@ -17,6 +17,7 @@ Transition = types.Transition
 
 def make_losses(
     config: NamedTuple,
+    env: object,
     contrastive_loss_fn: str,
     energy_fn: str,
     logsumexp_penalty: float,
@@ -34,7 +35,7 @@ def make_losses(
     parametric_action_distribution = crl_network.parametric_action_distribution
     sa_encoder = crl_network.sa_encoder
     g_encoder = crl_network.g_encoder
-    obs_dim = config.obs_dim
+    obs_dim = env.obs_dim
 
     def alpha_loss(
         log_alpha: jnp.ndarray,
@@ -61,6 +62,8 @@ def make_losses(
     ):
         # This is for debug purposes only
         if config.use_traj_idx_wrapper:
+            raise Exception("traj_index_wrapper_factory does not yet support the new goal indexing scheme.")
+            
             old_obs, info_1, info_2 = extract_info_from_obs(transitions.observation, config)
             jax.debug.print(
                 "OBS: \n{obs},\n\n info_1 \n{i_1},\n\n info_2 \n{i_2}\n\n", obs=old_obs, i_1=info_1, i_2=info_2
@@ -288,7 +291,7 @@ def make_losses(
         future_state = jnp.where(random_goal_mask, future_rolled, future_state)
         future_action = transitions.extras["future_action"]
 
-        goal = future_state[:, config.goal_start_idx : config.goal_end_idx]
+        goal = future_state[:, env.goal_indices]
 
         observation = jnp.concatenate([state, goal], axis=1)
 

--- a/src/networks.py
+++ b/src/networks.py
@@ -91,6 +91,7 @@ def make_inference_fn(crl_networks: CRLNetworks):
 
 def make_crl_networks(
     config: NamedTuple,
+    env: object,
     observation_size: int,
     action_size: int,
     preprocess_observations_fn: types.PreprocessObservationFn = types.identity_observation_preprocessor,
@@ -111,14 +112,14 @@ def make_crl_networks(
     )
     sa_encoder = make_embedder(
         layer_sizes=list(hidden_layer_sizes) + [config.repr_dim],
-        obs_size=config.obs_dim + action_size,
+        obs_size=env.obs_dim + action_size,
         activation=activation,
         preprocess_observations_fn=preprocess_observations_fn,
         use_ln=use_ln
     )
     g_encoder = make_embedder(
         layer_sizes=list(hidden_layer_sizes) + [config.repr_dim],
-        obs_size=config.goal_end_idx - config.goal_start_idx,
+        obs_size=len(env.goal_indices),
         activation=activation,
         preprocess_observations_fn=preprocess_observations_fn,
         use_ln=use_ln

--- a/training.py
+++ b/training.py
@@ -33,7 +33,7 @@ def render(inf_fun_factory, params, env, exp_dir, exp_name):
         if i % 1000 == 0:
             state = jit_env_reset(rng=rng)
 
-    url = html.render(env.sys.replace(dt=env.dt), rollout, height=1024)
+    url = html.render(env.sys.tree_replace({"opt.timestep": env.dt}), rollout, height=1024)
     with open(os.path.join(exp_dir, f"{exp_name}.html"), "w") as file:
         file.write(url)
     wandb.log({"render": wandb.Html(url)})
@@ -55,6 +55,7 @@ def main(args):
         pickle.dump(args, f)
 
     if args.use_traj_idx_wrapper:
+        raise Exception("traj_index_wrapper_factory does not yet support the new goal indexing scheme.")
         env, config = traj_index_wrapper_factory(env, config)
 
     train_fn = functools.partial(
@@ -165,7 +166,7 @@ if __name__ == "__main__":
         group=args.group_name,
         name=args.exp_name,
         config=vars(args),
-        mode="online" if args.log_wandb else "disabled",
+        mode=mode="online" if args.log_wandb else "disabled",
     )
 
     with Profiler(interval=0.1) as profiler:

--- a/training.py
+++ b/training.py
@@ -166,7 +166,7 @@ if __name__ == "__main__":
         group=args.group_name,
         name=args.exp_name,
         config=vars(args),
-        mode=mode="online" if args.log_wandb else "disabled",
+        mode="online" if args.log_wandb else "disabled",
     )
 
     with Profiler(interval=0.1) as profiler:

--- a/utils.py
+++ b/utils.py
@@ -17,7 +17,7 @@ from envs.ant_push import AntPush
 
 Config = namedtuple(
     "Config",
-    "debug discount obs_dim goal_start_idx goal_end_idx unroll_length episode_length repr_dim random_goals disable_entropy_actor use_traj_idx_wrapper",
+    "debug discount unroll_length episode_length repr_dim random_goals disable_entropy_actor use_traj_idx_wrapper",
 )
 
 
@@ -68,38 +68,18 @@ def create_env(args: argparse.Namespace) -> object:
     if env_name == "reacher":
         env = Reacher(backend=args.backend or "generalized")
     elif env_name == "ant":
-        env = Ant(
-            backend=args.backend or "spring",
-            exclude_current_positions_from_observation=False,
-            terminate_when_unhealthy=True,
-        )
+        env = Ant(backend=args.backend or "spring")
     elif env_name == "ant_ball":
-        env = AntBall(
-            backend=args.backend or "spring",
-            exclude_current_positions_from_observation=False,
-            terminate_when_unhealthy=True,
-        )
+        env = AntBall(backend=args.backend or "spring")
     elif env_name == "ant_push":
         # This is stable only in mjx backend
         assert args.backend == "mjx"
-        env = AntPush(
-            backend=args.backend,
-            exclude_current_positions_from_observation=False,
-            terminate_when_unhealthy=True,
-        )
+        env = AntPush(backend=args.backend)
     elif "maze" in env_name:
         # Possible env_name = {'ant_u_maze', 'ant_big_maze', 'ant_hardest_maze'}
-        env = AntMaze(
-            backend=args.backend or "spring",
-            exclude_current_positions_from_observation=False,
-            terminate_when_unhealthy=True,
-            maze_layout_name=env_name[4:]
-        )
+        env = AntMaze(backend=args.backend or "spring", maze_layout_name=env_name[4:])
     elif env_name == "cheetah":
-        env = Halfcheetah(
-            backend="mjx",
-            exclude_current_positions_from_observation=False,
-        )
+        env = Halfcheetah()
     elif env_name == "debug":
         env = Debug(backend=args.backend or "spring")
     elif env_name == "pusher_easy":
@@ -109,7 +89,7 @@ def create_env(args: argparse.Namespace) -> object:
     elif env_name == "pusher_reacher":
         env=PusherReacher(backend=args.backend or "generalized")
     elif env_name == "humanoid":
-        env=Humanoid(backend=args.backend)
+        env=Humanoid(backend=args.backend or "generalized")
     else:
         raise ValueError(f"Unknown environment: {env_name}")
     return env
@@ -128,9 +108,6 @@ def get_env_config(args: argparse.Namespace):
         config = Config(
             debug=True,
             discount=args.discounting,
-            obs_dim=3,
-            goal_start_idx=1,
-            goal_end_idx=3,
             unroll_length=args.unroll_length,
             episode_length=args.episode_length,
             repr_dim=args.repr_dim,
@@ -142,9 +119,6 @@ def get_env_config(args: argparse.Namespace):
         config = Config(
             debug=False,
             discount=args.discounting,
-            obs_dim=10,
-            goal_start_idx=4,
-            goal_end_idx=7,
             unroll_length=args.unroll_length,
             episode_length=args.episode_length,
             repr_dim=args.repr_dim,
@@ -156,9 +130,6 @@ def get_env_config(args: argparse.Namespace):
         config = Config(
             debug=False,
             discount=args.discounting,
-            obs_dim=18,
-            goal_start_idx=0,
-            goal_end_idx=1,
             unroll_length=args.unroll_length,
             episode_length=args.episode_length,
             repr_dim=args.repr_dim,
@@ -170,9 +141,6 @@ def get_env_config(args: argparse.Namespace):
         config = Config(
             debug=False,
             discount=args.discounting,
-            obs_dim=20,
-            goal_start_idx=10,
-            goal_end_idx=13,
             unroll_length=args.unroll_length,
             episode_length=args.episode_length,
             repr_dim=args.repr_dim,
@@ -184,9 +152,6 @@ def get_env_config(args: argparse.Namespace):
         config = Config(
             debug=False,
             discount=args.discounting,
-            obs_dim=17,
-            goal_start_idx=14,
-            goal_end_idx=17,
             unroll_length=args.unroll_length,
             episode_length=args.episode_length,
             repr_dim=args.repr_dim,
@@ -198,9 +163,6 @@ def get_env_config(args: argparse.Namespace):
         config = Config(
             debug=False,
             discount=args.discounting,
-            obs_dim=29,
-            goal_start_idx=0,
-            goal_end_idx=2,
             unroll_length=args.unroll_length,
             episode_length=args.episode_length,
             repr_dim=args.repr_dim,
@@ -212,9 +174,6 @@ def get_env_config(args: argparse.Namespace):
         config = Config(
             debug=False,
             discount=args.discounting,
-            obs_dim=31,
-            goal_start_idx=0,
-            goal_end_idx=2,
             unroll_length=args.unroll_length,
             episode_length=args.episode_length,
             repr_dim=args.repr_dim,
@@ -226,9 +185,6 @@ def get_env_config(args: argparse.Namespace):
         config = Config(
             debug=False,
             discount=args.discounting,
-            obs_dim=31,
-            goal_start_idx=-4,
-            goal_end_idx=-2,
             unroll_length=args.unroll_length,
             episode_length=args.episode_length,
             repr_dim=args.repr_dim,
@@ -240,9 +196,6 @@ def get_env_config(args: argparse.Namespace):
         config = Config(
             debug=False,
             discount=args.discounting,
-            obs_dim=268,
-            goal_start_idx=0,
-            goal_end_idx=3,
             unroll_length=args.unroll_length,
             episode_length=args.episode_length,
             repr_dim=args.repr_dim,


### PR DESCRIPTION
Preparatory PR -- new 7DoF arm environments coming in a separate PR after this merge is edited/approved.

Goal specification:
- Environments previously use contiguous subsequences for goal indices, i.e. goal_indices = [goal_start_idx, goal_end_idx). Sometimes these indices are difficult to merge together, and this PR refactors them into a more flexible definition of goal_indices (arbitrary indices).
- All environments have goal_indices specified, and references to goal start/end indices are replayed with goal_indices

Cleaning up utils.py defaults:
- Goal indices moved to be within the environment, rather than in the config. This seems to be more natural than defining it separately in utils.py
- Similarly, obs_dim is moved within the environment rather than config; corresponding calls requiring environments have been replaced.
- create_env overrides default __init__ arguments in some environments with, effectively, new defaults; they have been moved from create_env directly into the defaults in __init__.

Upgraded compatibility for brax/mjx:
- Updated environment.yml; moved brax from conda-forge to pip because newest version is not in conda-forge
- env.sys.dt replacements now swapped with tree_replace with env.sys.opt.timestep (brax 0.10.4 requirement)
- Newest mjx version additionally supports tendons, implicitfast integrator, etc.

Changes were tested with Ant and Humanoid, and seem to preserve performance parity + no errors.