### PR TITLE
Upload Chirayu and Shlok's MPE env wrappers and training script for MARL

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Reach out and start contributing or just add an Issue/PR!
 - [ ] Add more complex versions of Ant Sokoban.
 - [ ] Get around 70% success rate on Ant Big Maze task.
 - [ ] Integrate environments: 
+    - [x] Multi Particle Environments (MPE) [Done by Chirayu Nimonkar and Shlok Shah]
     - [ ] Overcooked 
     - [ ] Hanabi
     - [ ] Rubik's cube

--- a/clean_JaxGCRL/train_crl_marl.py
+++ b/clean_JaxGCRL/train_crl_marl.py
@@ -1,0 +1,716 @@
+# Training script for JaxMARL environments (MPE). 
+# Currently all policies share the same network.
+
+import os
+import jax
+import flax
+import tyro
+import time
+import optax
+import wandb
+import pickle
+import random
+import wandb_osh
+import numpy as np
+import flax.linen as nn
+import jax.numpy as jnp
+
+from brax import envs
+from etils import epath
+from dataclasses import dataclass
+from collections import namedtuple
+from typing import NamedTuple, Any
+from wandb_osh.hooks import TriggerWandbSyncHook
+from flax.training.train_state import TrainState
+from flax.linen.initializers import variance_scaling
+
+from evaluator import CrlEvaluator
+from buffer import TrajectoryUniformSamplingQueue
+
+# With the multi-policy idea, all that would be need to be changed would be many different actor_params in the actor_state
+
+# List of modifications so far:
+# actor_step, deterministic_actor_step, simple env if statement, replay buffer initialization, checkpoint loading
+
+#intended modifications:
+#decrease the max replay size in accordance with num agents
+#notice that this gives the same effect as not making new buffers for agents and
+#instead putting the agent trajectories one after the other in the same buffer
+
+@dataclass
+class Args:
+    exp_name: str = os.path.basename(__file__)[: -len(".py")]
+    seed: int = 1
+    torch_deterministic: bool = True
+    cuda: bool = True
+    track: bool = False
+    wandb_project_name: str = "exploration"
+    wandb_entity: str = 'raj19'
+    wandb_mode: str = 'online'
+    wandb_dir: str = '.'
+    wandb_group: str = '.'
+    capture_video: bool = False
+    checkpoint: bool = False
+    load_path: str = ''
+
+    #environment specific arguments
+    env_id: str = "mpe_tag"
+    episode_length: int = 1000
+    # to be filled in runtime
+    obs_dim: int = 0
+    goal_start_idx: int = 0
+    goal_end_idx: int = 0
+    num_agents: int = 0
+
+    # Algorithm specific arguments
+    total_env_steps: int = 50000000
+    num_epochs: int = 50
+    num_envs: int = 256
+    num_eval_envs: int = 64
+    actor_lr: float = 3e-4
+    critic_lr: float = 3e-4
+    alpha_lr: float = 3e-4
+    batch_size: int = 256
+    gamma: float = 0.99
+    logsumexp_penalty_coeff: float = 0.1
+
+    max_replay_size: int = 10000
+    min_replay_size: int = 1000
+    
+    unroll_length: int  = 62
+
+    # to be filled in runtime
+    env_steps_per_actor_step : int = 0
+    """number of env steps per actor step (computed in runtime)"""
+    num_prefill_env_steps : int = 0
+    """number of env steps to fill the buffer before starting training (computed in runtime)"""
+    num_prefill_actor_steps : int = 0
+    """number of actor steps to fill the buffer before starting training (computed in runtime)"""
+    num_training_steps_per_epoch : int = 0
+    """the number of training steps per epoch(computed in runtime)"""
+    num_envs_agents : int = 0
+    """the number of agents times the number of environments (2nd dimension replay buffer)"""
+
+class SA_encoder(nn.Module):
+    norm_type = "layer_norm"
+    @nn.compact
+    def __call__(self, s: jnp.ndarray, a: jnp.ndarray):
+
+        lecun_unfirom = variance_scaling(1/3, "fan_in", "uniform")
+        bias_init = nn.initializers.zeros
+        
+        if self.norm_type == "layer_norm":
+            normalize = lambda x: nn.LayerNorm()(x)
+        else:
+            normalize = lambda x: x
+
+        x = jnp.concatenate([s, a], axis=-1)
+        x = nn.Dense(1024, kernel_init=lecun_unfirom, bias_init=bias_init)(x)
+        x = normalize(x)
+        x = nn.swish(x)
+        x = nn.Dense(1024, kernel_init=lecun_unfirom, bias_init=bias_init)(x)
+        x = normalize(x)
+        x = nn.swish(x)
+        x = nn.Dense(1024, kernel_init=lecun_unfirom, bias_init=bias_init)(x)
+        x = normalize(x)
+        x = nn.swish(x)
+        x = nn.Dense(1024, kernel_init=lecun_unfirom, bias_init=bias_init)(x)
+        x = normalize(x)
+        x = nn.swish(x)
+        x = nn.Dense(64, kernel_init=lecun_unfirom, bias_init=bias_init)(x)
+        return x
+    
+class G_encoder(nn.Module):
+    norm_type = "layer_norm"
+    @nn.compact
+    def __call__(self, g: jnp.ndarray):
+
+        lecun_unfirom = variance_scaling(1/3, "fan_in", "uniform")
+        bias_init = nn.initializers.zeros
+
+        if self.norm_type == "layer_norm":
+            normalize = lambda x: nn.LayerNorm()(x)
+        else:
+            normalize = lambda x: x
+
+        x = nn.Dense(1024, kernel_init=lecun_unfirom, bias_init=bias_init)(g)
+        x = normalize(x)
+        x = nn.swish(x)
+        x = nn.Dense(1024, kernel_init=lecun_unfirom, bias_init=bias_init)(x)
+        x = normalize(x)
+        x = nn.swish(x)
+        x = nn.Dense(1024, kernel_init=lecun_unfirom, bias_init=bias_init)(x)
+        x = normalize(x)
+        x = nn.swish(x)
+        x = nn.Dense(1024, kernel_init=lecun_unfirom, bias_init=bias_init)(x)
+        x = normalize(x)
+        x = nn.swish(x)
+        x = nn.Dense(64, kernel_init=lecun_unfirom, bias_init=bias_init)(x)
+        return x
+
+class Actor(nn.Module):
+    action_size: int
+    norm_type = "layer_norm"
+
+    LOG_STD_MAX = 2
+    LOG_STD_MIN = -5
+
+    @nn.compact
+    def __call__(self, x):
+        if self.norm_type == "layer_norm":
+            normalize = lambda x: nn.LayerNorm()(x)
+        else:
+            normalize = lambda x: x
+
+        lecun_unfirom = variance_scaling(1/3, "fan_in", "uniform")
+        bias_init = nn.initializers.zeros
+
+        x = nn.Dense(1024, kernel_init=lecun_unfirom, bias_init=bias_init)(x)
+        x = normalize(x)
+        x = nn.swish(x)
+        x = nn.Dense(1024, kernel_init=lecun_unfirom, bias_init=bias_init)(x)
+        x = normalize(x)
+        x = nn.swish(x)
+        x = nn.Dense(1024, kernel_init=lecun_unfirom, bias_init=bias_init)(x)
+        x = normalize(x)
+        x = nn.swish(x)
+        x = nn.Dense(1024, kernel_init=lecun_unfirom, bias_init=bias_init)(x)
+        x = normalize(x)
+        x = nn.swish(x)
+
+        mean = nn.Dense(self.action_size, kernel_init=lecun_unfirom, bias_init=bias_init)(x)
+        log_std = nn.Dense(self.action_size, kernel_init=lecun_unfirom, bias_init=bias_init)(x)
+        
+        log_std = nn.tanh(log_std)
+        log_std = self.LOG_STD_MIN + 0.5 * (self.LOG_STD_MAX - self.LOG_STD_MIN) * (log_std + 1)  # From SpinUp / Denis Yarats
+
+        return mean, log_std
+
+@flax.struct.dataclass
+class TrainingState:
+    """Contains training state for the learner"""
+    env_steps: jnp.ndarray
+    gradient_steps: jnp.ndarray
+    actor_state: TrainState
+    critic_state: TrainState
+    alpha_state: TrainState
+
+class Transition(NamedTuple):
+    """Container for a transition"""
+    observation: jnp.ndarray
+    action: jnp.ndarray
+    reward: jnp.ndarray
+    discount: jnp.ndarray
+    extras: jnp.ndarray = ()  
+
+def load_params(path: str):
+    with epath.Path(path).open('rb') as fin:
+        buf = fin.read()
+    return pickle.loads(buf)
+
+def save_params(path: str, params: Any):
+    """Saves parameters in flax format."""
+    with epath.Path(path).open('wb') as fout:
+        fout.write(pickle.dumps(params))
+                   
+if __name__ == "__main__":
+
+    args = tyro.cli(Args)
+
+    args.env_steps_per_actor_step = args.num_envs * args.unroll_length
+    args.num_prefill_env_steps = args.min_replay_size * args.num_envs
+    args.num_prefill_actor_steps = np.ceil(args.min_replay_size / args.unroll_length)
+    args.num_training_steps_per_epoch = (args.total_env_steps - args.num_prefill_env_steps) // (args.num_epochs * args.env_steps_per_actor_step)
+
+    run_name = f"{args.env_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
+
+    if args.track:
+
+        if args.wandb_group ==  '.':
+            args.wandb_group = None
+            
+        wandb.init(
+            project=args.wandb_project_name,
+            entity=args.wandb_entity,
+            mode=args.wandb_mode,
+            group=args.wandb_group,
+            dir=args.wandb_dir,
+            config=vars(args),
+            name=run_name,
+            monitor_gym=True,
+            save_code=True,
+        )
+
+        if args.wandb_mode == 'offline':
+            wandb_osh.set_log_level("ERROR")
+            trigger_sync = TriggerWandbSyncHook()
+        
+    if args.checkpoint:
+        from pathlib import Path
+        save_path = Path(args.wandb_dir) / Path(run_name)
+        os.mkdir(path=save_path)
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    key = jax.random.PRNGKey(args.seed)
+    key, buffer_key, env_key, eval_env_key, actor_key, sa_key, g_key = jax.random.split(key, 7)
+
+    # Environment setup    
+    if args.env_id == "ant":
+        from envs.ant import Ant
+        env = Ant(
+            backend="spring",
+            exclude_current_positions_from_observation=False,
+            terminate_when_unhealthy=True,
+        )
+
+        args.obs_dim = 29
+        args.goal_start_idx = 0
+        args.goal_end_idx = 2
+
+    elif "maze" in args.env_id:
+        from envs.ant_maze import AntMaze
+        env = AntMaze(
+            backend="spring",
+            exclude_current_positions_from_observation=False,
+            terminate_when_unhealthy=True,
+            maze_layout_name=args.env_id[4:]
+        )
+
+        args.obs_dim = 29
+        args.goal_start_idx = 0
+        args.goal_end_idx = 2
+    
+    elif args.env_id == "simple_marl":
+        from envs.mpe_simple_marl import SimpleMPEMARL
+        env = SimpleMPEMARL()
+        args.obs_dim = 4
+        args.goal_start_idx = 2
+        args.goal_end_idx = 4
+        args.num_agents = env.env.num_agents
+        args.num_envs_agents = args.num_envs * args.num_agents
+    
+    elif args.env_id == "push_marl":
+        from envs.mpe_push_LLM import PushMPEMARL
+        env = PushMPEMARL()
+        args.obs_dim = 6  # vel(2) + landmark_pos(4)
+        args.goal_start_idx = 6  # target position starts after obs
+        args.goal_end_idx = 8   # target is 2D position
+        args.num_agents = env.env.num_agents
+        args.num_envs_agents = args.num_envs * args.num_agents
+
+    elif args.env_id == "mpe_tag":
+        from envs.mpe_tag import MPETagCoop
+        env = MPETagCoop()
+        args.obs_dim = env.observation_size - 1
+        args.goal_start_idx = env.observation_size - 2
+        args.goal_end_idx = env.observation_size - 1
+        args.num_agents = env.env.num_adversaries
+        args.num_envs_agents = args.num_envs * args.num_agents
+
+    else:
+        raise NotImplementedError
+
+    env = envs.training.wrap(
+        env,
+        episode_length=args.episode_length,
+    )
+
+    obs_size = env.observation_size
+    action_size = env.action_size
+    env_keys = jax.random.split(env_key, args.num_envs)
+    env_state = jax.jit(env.reset)(env_keys)
+    env.step = jax.jit(env.step)
+    
+    #load checkpoint to resume training
+    alph_params, act_params, crtc_params = load_params(args.load_path) if args.load_path else [None]*3
+
+    # Network setup
+    # Actor
+    actor = Actor(action_size=action_size)
+    if not act_params:
+        act_params = actor.init(actor_key, np.ones([1, obs_size]))
+    actor_state = TrainState.create(
+        apply_fn=actor.apply,
+        params=act_params,
+        tx=optax.adam(learning_rate=args.actor_lr)
+    )
+
+    # Critic
+    sa_encoder = SA_encoder()
+    sa_encoder_params = sa_encoder.init(sa_key, np.ones([1, args.obs_dim]), np.ones([1, action_size]))
+    g_encoder = G_encoder()
+    g_encoder_params = g_encoder.init(g_key, np.ones([1, args.goal_end_idx - args.goal_start_idx]))
+    c = jnp.asarray(0.0, dtype=jnp.float32)
+    if not crtc_params:
+        crtc_params = {"sa_encoder": sa_encoder_params, "g_encoder": g_encoder_params}
+    critic_state = TrainState.create(
+        apply_fn=None,
+        params={"sa_encoder": sa_encoder_params, "g_encoder": g_encoder_params},
+        tx=optax.adam(learning_rate=args.critic_lr),
+    )
+
+    # Entropy coefficient
+    target_entropy = -0.5 * action_size
+    log_alpha = jnp.asarray(0.0, dtype=jnp.float32)
+    if not alph_params:
+        alph_params = {"log_alpha": log_alpha}
+    alpha_state = TrainState.create(
+        apply_fn=None,
+        params=alph_params,
+        tx=optax.adam(learning_rate=args.alpha_lr),
+    )
+    
+    # Trainstate
+    training_state = TrainingState(
+        env_steps=jnp.zeros(()),
+        gradient_steps=jnp.zeros(()),
+        actor_state=actor_state,
+        critic_state=critic_state,
+        alpha_state=alpha_state,
+    )
+
+    #Replay Buffer
+    dummy_obs = jnp.zeros((obs_size,))
+    dummy_action = jnp.zeros((action_size,))
+
+    dummy_transition = Transition(
+        observation=dummy_obs,
+        action=dummy_action,
+        reward=0.0,
+        discount=0.0,
+        extras={
+            "state_extras": {
+                "truncation": 0.0,
+                "seed": 0.0,
+            }        
+        },
+    )
+
+    def jit_wrap(buffer):
+        buffer.insert_internal = jax.jit(buffer.insert_internal)
+        buffer.sample_internal = jax.jit(buffer.sample_internal)
+        return buffer
+    
+    #change replay buffer to make the 2nd dimension num_envs_agents
+    replay_buffer = jit_wrap(
+            TrajectoryUniformSamplingQueue(
+                max_replay_size=args.max_replay_size,
+                dummy_data_sample=dummy_transition,
+                sample_batch_size=args.batch_size,
+                num_envs=args.num_envs_agents,
+                episode_length=args.episode_length,
+            )
+        )
+    buffer_state = jax.jit(replay_buffer.init)(buffer_key)
+
+    #modified to have extra dimension for multiple agents
+    def deterministic_actor_step(training_state, env, env_state, extra_fields):
+        obs = jnp.reshape(env_state.obs, (-1,) + env_state.obs.shape[2:])
+        means, _ = actor.apply(actor_state.params, obs)
+        actions = nn.tanh( means )
+        
+        actions_ = jnp.reshape(actions, (-1, args.num_agents,) + actions.shape[1:])
+        nstate = env.step(env_state, actions_)
+        
+        state_extras = {x: jnp.repeat(nstate.info[x], args.num_agents) for x in extra_fields}
+        return nstate, Transition(
+            observation=obs,
+            action=actions,
+            reward=jnp.repeat(nstate.reward, args.num_agents),
+            discount=jnp.repeat(1-nstate.done, args.num_agents),
+            extras={"state_extras": state_extras},
+        )
+
+    
+    #modified to have extra dimension for multiple agents
+    def actor_step(actor_state, env, env_state, key, extra_fields):
+        #perform inference to get actions
+        keys = jax.random.split(key, args.num_agents)
+        obs = jnp.reshape(env_state.obs, (-1,) + env_state.obs.shape[2:])
+        means, log_stds = actor.apply(actor_state.params, obs)
+        stds = jnp.exp(log_stds)
+        noise = jax.vmap(lambda rng: jax.random.normal(
+                    rng, shape=(args.num_envs,) + means.shape[1:], 
+                    dtype=means.dtype), in_axes=0, out_axes=1)(keys)
+        noise_ = jnp.reshape(noise, (-1,) + noise.shape[2:])
+        actions = nn.tanh( means + stds * noise_)
+            
+        #step our environment
+        actions_ = jnp.reshape(actions, (-1, args.num_agents,) + actions.shape[1:])
+        nstate = env.step(env_state, actions_)
+        
+        #generate an array of transitions, with shape (num_envs*num_agents,...)
+        state_extras = {x: jnp.repeat(nstate.info[x], args.num_agents) for x in extra_fields}
+
+        return nstate, Transition(
+            observation=obs,
+            action=actions,
+            reward=jnp.repeat(nstate.reward, args.num_agents),
+            discount=jnp.repeat(1-nstate.done, args.num_agents),
+            extras={"state_extras": state_extras},
+        )
+
+    @jax.jit
+    def get_experience(actor_state, env_state, buffer_state, key):
+        @jax.jit
+        def f(carry, unused_t):
+            env_state, current_key = carry
+            current_key, next_key = jax.random.split(current_key)
+            env_state, transition = actor_step(actor_state, env, env_state, current_key, extra_fields=("truncation", "seed"))
+            return (env_state, next_key), transition
+
+        (env_state, _), data = jax.lax.scan(f, (env_state, key), (), length=args.unroll_length)
+
+        buffer_state = replay_buffer.insert(buffer_state, data)
+        return env_state, buffer_state
+
+    def prefill_replay_buffer(training_state, env_state, buffer_state, key):
+        @jax.jit
+        def f(carry, unused):
+            del unused
+            training_state, env_state, buffer_state, key = carry
+            key, new_key = jax.random.split(key)
+            env_state, buffer_state = get_experience(
+                training_state.actor_state,
+                env_state,
+                buffer_state,
+                key,
+            
+            )
+            training_state = training_state.replace(
+                env_steps=training_state.env_steps + args.env_steps_per_actor_step,
+            )
+            return (training_state, env_state, buffer_state, new_key), ()
+
+        return jax.lax.scan(f, (training_state, env_state, buffer_state, key), (), length=args.num_prefill_actor_steps)[0]
+
+    @jax.jit
+    def update_actor_and_alpha(transitions, training_state, key):
+        def actor_loss(actor_params, critic_params, log_alpha, transitions, key):
+            obs = transitions.observation           # expected_shape = batch_size, obs_size + goal_size
+            state = obs[:, :args.obs_dim]
+            future_state = transitions.extras["future_state"]
+            goal = future_state[:, args.goal_start_idx : args.goal_end_idx]
+            observation = jnp.concatenate([state, goal], axis=1)
+
+            means, log_stds = actor.apply(actor_params, observation)
+            stds = jnp.exp(log_stds)
+            x_ts = means + stds * jax.random.normal(key, shape=means.shape, dtype=means.dtype)
+            action = nn.tanh(x_ts)
+            log_prob = jax.scipy.stats.norm.logpdf(x_ts, loc=means, scale=stds)
+            log_prob -= jnp.log((1 - jnp.square(action)) + 1e-6)
+            log_prob = log_prob.sum(-1)           # dimension = B
+
+            sa_encoder_params, g_encoder_params = critic_params["sa_encoder"], critic_params["g_encoder"]
+            sa_repr = sa_encoder.apply(sa_encoder_params, state, action)
+            g_repr = g_encoder.apply(g_encoder_params, goal)
+
+            qf_pi = -jnp.sqrt(jnp.sum((sa_repr - g_repr) ** 2, axis=-1))
+
+            actor_loss = jnp.mean( jnp.exp(log_alpha) * log_prob - (qf_pi) )
+
+            return actor_loss, log_prob
+
+        def alpha_loss(alpha_params, log_prob):
+            alpha = jnp.exp(alpha_params["log_alpha"])
+            alpha_loss = alpha * jnp.mean(jax.lax.stop_gradient(-log_prob - target_entropy))
+            return jnp.mean(alpha_loss)
+        
+        (actorloss, log_prob), actor_grad = jax.value_and_grad(actor_loss, has_aux=True)(training_state.actor_state.params, training_state.critic_state.params, training_state.alpha_state.params['log_alpha'], transitions, key)
+        new_actor_state = training_state.actor_state.apply_gradients(grads=actor_grad)
+
+        alphaloss, alpha_grad = jax.value_and_grad(alpha_loss)(training_state.alpha_state.params, log_prob)
+        new_alpha_state = training_state.alpha_state.apply_gradients(grads=alpha_grad)
+
+        training_state = training_state.replace(actor_state=new_actor_state, alpha_state=new_alpha_state)
+
+        metrics = {
+            "sample_entropy": -log_prob,
+            "actor_loss": actorloss,
+            "alph_aloss": alphaloss,   
+            "log_alpha": training_state.alpha_state.params["log_alpha"],
+        }
+
+        return training_state, metrics
+
+    @jax.jit
+    def update_critic(transitions, training_state, key):
+        def critic_loss(critic_params, transitions, key):
+            sa_encoder_params, g_encoder_params = critic_params["sa_encoder"], critic_params["g_encoder"]
+            
+            obs = transitions.observation[:, :args.obs_dim]
+            action = transitions.action
+            
+            sa_repr = sa_encoder.apply(sa_encoder_params, obs, action)
+            g_repr = g_encoder.apply(g_encoder_params, transitions.observation[:, args.obs_dim:])
+            
+            # InfoNCE
+            logits = -jnp.sqrt(jnp.sum((sa_repr[:, None, :] - g_repr[None, :, :]) ** 2, axis=-1))       # shape = BxB
+            critic_loss = -jnp.mean(jnp.diag(logits) - jax.nn.logsumexp(logits, axis=1))
+
+            # logsumexp regularisation
+            logsumexp = jax.nn.logsumexp(logits + 1e-6, axis=1)
+            critic_loss += args.logsumexp_penalty_coeff * jnp.mean(logsumexp**2)
+
+            I = jnp.eye(logits.shape[0])
+            correct = jnp.argmax(logits, axis=1) == jnp.argmax(I, axis=1)
+            logits_pos = jnp.sum(logits * I) / jnp.sum(I)
+            logits_neg = jnp.sum(logits * (1 - I)) / jnp.sum(1 - I)
+
+            return critic_loss, (logsumexp, I, correct, logits_pos, logits_neg)
+            
+        (loss, (logsumexp, I, correct, logits_pos, logits_neg)), grad = jax.value_and_grad(critic_loss, has_aux=True)(training_state.critic_state.params, transitions, key)
+        new_critic_state = training_state.critic_state.apply_gradients(grads=grad)
+        training_state = training_state.replace(critic_state = new_critic_state)
+
+        metrics = {
+            "categorical_accuracy": jnp.mean(correct),
+            "logits_pos": logits_pos,
+            "logits_neg": logits_neg,
+            "logsumexp": logsumexp.mean(),
+            "critic_loss": loss,
+        }
+
+        return training_state, metrics
+    
+    @jax.jit
+    def sgd_step(carry, transitions):
+        training_state, key = carry
+        key, critic_key, actor_key, = jax.random.split(key, 3)
+
+        training_state, actor_metrics = update_actor_and_alpha(transitions, training_state, actor_key)
+
+        training_state, critic_metrics = update_critic(transitions, training_state, critic_key)
+
+        training_state = training_state.replace(gradient_steps = training_state.gradient_steps + 1)
+
+        metrics = {}
+        metrics.update(actor_metrics)
+        metrics.update(critic_metrics)
+        
+        return (training_state, key,), metrics
+
+    @jax.jit
+    def training_step(training_state, env_state, buffer_state, key):
+        experience_key1, experience_key2, sampling_key, training_key = jax.random.split(key, 4)
+
+        # update buffer
+        env_state, buffer_state = get_experience(
+            training_state.actor_state,
+            env_state,
+            buffer_state,
+            experience_key1,
+        )
+
+        training_state = training_state.replace(
+            env_steps=training_state.env_steps + args.env_steps_per_actor_step,
+        )
+
+        # sample actor-step worth of transitions
+        buffer_state, transitions = replay_buffer.sample(buffer_state)
+
+        # process transitions for training
+        batch_keys = jax.random.split(sampling_key, transitions.observation.shape[0])
+        transitions = jax.vmap(TrajectoryUniformSamplingQueue.flatten_crl_fn, in_axes=(None, 0, 0))(
+            (args.gamma, args.obs_dim, args.goal_start_idx, args.goal_end_idx), transitions, batch_keys
+        )
+        
+        transitions = jax.tree_util.tree_map(
+            lambda x: jnp.reshape(x, (-1,) + x.shape[2:], order="F"),
+            transitions,
+        )
+        permutation = jax.random.permutation(experience_key2, len(transitions.observation))
+        transitions = jax.tree_util.tree_map(lambda x: x[permutation], transitions)
+        transitions = jax.tree_util.tree_map(
+            lambda x: jnp.reshape(x, (-1, args.batch_size) + x.shape[1:]),
+            transitions,
+        )
+
+        # take actor-step worth of training-step
+        (training_state, _,), metrics = jax.lax.scan(sgd_step, (training_state, training_key), transitions)
+
+        return (training_state, env_state, buffer_state,), metrics
+
+    @jax.jit
+    def training_epoch(
+        training_state,
+        env_state,
+        buffer_state,
+        key,
+    ):  
+        @jax.jit
+        def f(carry, unused_t):
+            ts, es, bs, k = carry
+            k, train_key = jax.random.split(k, 2)
+            (ts, es, bs,), metrics = training_step(ts, es, bs, train_key)
+            return (ts, es, bs, k), metrics
+
+        (training_state, env_state, buffer_state, key), metrics = jax.lax.scan(f, (training_state, env_state, buffer_state, key), (), length=args.num_training_steps_per_epoch)
+        
+        metrics["buffer_current_size"] = replay_buffer.size(buffer_state)
+        return training_state, env_state, buffer_state, metrics
+
+    key, prefill_key = jax.random.split(key, 2)
+
+    training_state, env_state, buffer_state, _ = prefill_replay_buffer(
+        training_state, env_state, buffer_state, prefill_key
+    )
+
+    '''Setting up evaluator'''
+    evaluator = CrlEvaluator(
+        deterministic_actor_step,
+        env,
+        num_eval_envs=args.num_eval_envs,
+        episode_length=args.episode_length,
+        key=eval_env_key,
+    )
+
+    training_walltime = 0
+    print('starting training....')
+    for ne in range(args.num_epochs):
+        
+        t = time.time()
+
+        key, epoch_key = jax.random.split(key)
+        training_state, env_state, buffer_state, metrics = training_epoch(training_state, env_state, buffer_state, epoch_key)
+        
+        metrics = jax.tree_util.tree_map(jnp.mean, metrics)
+        metrics = jax.tree_util.tree_map(lambda x: x.block_until_ready(), metrics)
+
+        epoch_training_time = time.time() - t
+        training_walltime += epoch_training_time
+
+        sps = (args.env_steps_per_actor_step * args.num_training_steps_per_epoch) / epoch_training_time
+        metrics = {
+            "training/sps": sps,
+            "training/walltime": training_walltime,
+            "training/envsteps": training_state.env_steps.item(),
+            **{f"training/{name}": value for name, value in metrics.items()},
+        }
+
+        metrics = evaluator.run_evaluation(training_state, metrics)
+
+        print(metrics)
+
+        if args.checkpoint:
+            # Save current policy and critic params.
+            params = (training_state.alpha_state.params, training_state.actor_state.params, training_state.critic_state.params)
+            path = f"{save_path}/step_{int(training_state.env_steps)}.pkl"
+            save_params(path, params)
+        
+        if args.track:
+            wandb.log(metrics, step=ne)
+
+            if args.wandb_mode == 'offline':
+                trigger_sync()
+    
+    if args.checkpoint:
+        # Save current policy and critic params.
+        params = (training_state.alpha_state.params, training_state.actor_state.params, training_state.critic_state.params)
+        path = f"{save_path}/final.pkl"
+        save_params(path, params)
+        
+# (50000000 - 1024 x 1000) / 50 x 1024 x 62 = 15        #number of actor steps per epoch (which is equal to the number of training steps)
+# 1024 x 999 / 256 = 4000                               #number of gradient steps per actor step 
+# 1024 x 62 / 4000 = 16                                 #ratio of env steps per gradient step

--- a/envs/mpe_simple.py
+++ b/envs/mpe_simple.py
@@ -1,0 +1,107 @@
+from typing import Tuple
+from brax import base
+from brax.envs.base import State, Env
+import jax
+from jax import numpy as jp
+from jaxmarl.environments.mpe import simple
+
+# Changes made:
+# All obs and actions are typed as arrays instead of dicts when sent/received
+# This invariant exists to maintain training script convention
+# We convert to dicts in this env class
+
+# TODO: metrics update in state info if want to
+
+NUM_AGENTS = 2
+
+class SimpleMPEMARL(Env):
+    def __init__(self):
+        self.env = simple.SimpleMPE(num_agents = NUM_AGENTS, action_type="Continuous")
+
+    def get_obs(self, state, obs, targets):
+        def create_obs(ob, target):
+            abs_pos = state.p_pos[self.env.num_agents] - ob[2:] #subtract rel pos from landmark pos
+            return jp.concatenate((ob[:2], abs_pos, target), axis=0)
+          
+        return jp.stack(list(jax.tree.map(create_obs, obs, targets).values())) #convert dict to jp array
+
+    @property
+    def observation_size(self) -> int:
+        return 6 #vel, pos, target_pos
+
+    @property
+    def action_size(self) -> int:
+        return 5 #from simple mpe documentation
+
+    @property
+    def backend(self) -> str:
+        raise Exception("This environment does not use a brax backend")
+        return "There is no backend!!!"
+
+    def reset(self, rng: jax.Array) -> State:
+        """Resets the environment to an initial state."""
+        key1, key2, key3 = jax.random.split(rng, 3)
+        
+        # Set the targets
+        targets = self._random_target(key1)
+
+        # Reset the internal MPE environment
+        obs, state = self.env.reset(key2)
+
+        reward, done, zero = jp.zeros(3)
+        metrics = {
+            "reward_forward": zero,
+            "reward_survive": zero,
+            "reward_ctrl": zero,
+            "reward_contact": zero,
+            "x_position": zero,
+            "y_position": zero,
+            "distance_from_origin": zero,
+            "x_velocity": zero,
+            "y_velocity": zero,
+            "forward_reward": zero,
+            "dist": zero,
+            "success": zero,
+            "success_easy": zero
+        }
+        info = {"seed": 0, "mpe_key": key3, "mpe_target": targets}
+
+        state = State(state, self.get_obs(state, obs, targets), reward, done, metrics)
+        state.info.update(info)
+        return state
+
+    def step(self, state: State, action: jax.Array) -> State:
+        """Run one timestep of the environment's dynamics."""
+        key, key_s = jax.random.split(state.info["mpe_key"], 2)
+        
+        # Generate action dict
+        actions = {agent: action[i] for i, agent in enumerate(self.env.agents)}
+        
+        # Step internal environment
+        obs, mpe_state, rewards, dones, infos = self.env.step(key_s, state.pipeline_state, actions)
+
+        # Process obs into our format
+        obs = self.get_obs(mpe_state, obs, state.info["mpe_target"])
+        
+        # Set trajectory id to differentiate between episodes
+        if "steps" in state.info.keys():
+            seed = state.info["seed"] + jp.where(state.info["steps"], 0, 1)
+        else:
+            seed = state.info["seed"]
+        info = {"seed": seed, "mpe_key": key}
+        state.info.update(info)
+        
+        reward, _ = jp.zeros(2)
+        return state.replace(
+            pipeline_state=mpe_state, obs=obs, reward=reward, done=list(dones.values())[0].astype(jp.float32)
+        )
+    
+    # Generate uniformly random target for each agent
+    def _random_target(self, rng: jax.Array) -> Tuple[jax.Array, jax.Array]:
+        keys = jax.random.split(rng, self.env.num_agents)
+        dist = 1
+        ang = jp.pi * 2.0 * jax.vmap(jax.random.uniform)(keys)
+        target_x = dist * jp.cos(ang)
+        target_y = dist * jp.sin(ang)
+        target_arr = jp.concatenate((target_x[:,None], target_y[:,None]), axis=1)
+        return {a: target_arr[i] for i, a in enumerate(self.env.agents)}

--- a/envs/mpe_tag.py
+++ b/envs/mpe_tag.py
@@ -1,0 +1,113 @@
+from typing import Tuple
+from brax import base
+from brax.envs.base import State, Env
+import jax
+from jax import numpy as jp
+from jaxmarl.environments.mpe import simple_tag
+
+NUM_GOOD = 1
+NUM_ADV = 3
+NUM_OBS = 10
+
+class MPETagCoop(Env):
+    def __init__(self):
+        self.env = simple_tag.SimpleTagMPE(
+            num_good_agents=NUM_GOOD,
+            num_adversaries=NUM_ADV,
+            num_obs=NUM_OBS,
+            action_type="Continuous")
+
+    def get_obs(self, state, obs):
+        adv_obs = jp.array([obs[a] for a in self.env.adversaries])
+        good_obs = jp.array([obs[a] for a in self.env.good_agents])
+        adv_pos, good_pos = adv_obs[:,2:4], good_obs[:,2:4]
+        dist_mat = (adv_pos[:,None,:] - good_pos[None,:,:])**2
+        dist_mat = jp.sum(dist_mat, axis=2)
+        min_dist = jp.min(dist_mat)
+        
+        add_obs = jp.zeros((adv_obs.shape[0], 2))
+        add_obs = add_obs.at[:,0].set(min_dist)
+        return jp.concatenate((adv_obs, add_obs), axis=1)
+                
+    @property
+    def observation_size(self) -> int:
+        return 4 + 2*NUM_OBS + 2*(self.env.num_agents-1) + 2*(NUM_GOOD) + 2 # pos, vel, landmarks, other_pos, other_vel, dist, goal
+
+    @property
+    def action_size(self) -> int:
+        return 5 # From simple mpe documentation
+
+    @property
+    def backend(self) -> str:
+        raise Exception("This environment does not use a brax backend")
+        return "There is no backend!!!"
+
+    def reset(self, rng: jax.Array) -> State:
+        """Resets the environment to an initial state."""
+        key1, key2, key3 = jax.random.split(rng, 3)
+        
+        # Reset the internal MPE environment
+        obs, state = self.env.reset(key2)
+
+        reward, done, zero = jp.zeros(3)
+        metrics = {
+            "reward_forward": zero,
+            "reward_survive": zero,
+            "reward_ctrl": zero,
+            "reward_contact": zero,
+            "x_position": zero,
+            "y_position": zero,
+            "distance_from_origin": zero,
+            "x_velocity": zero,
+            "y_velocity": zero,
+            "forward_reward": zero,
+            "dist": zero,
+            "success": zero,
+            "success_easy": zero
+        }
+        info = {"seed": 0, "mpe_key": key3, "mpe_target": 0}
+
+        state = State(state, self.get_obs(state, obs), reward, done, metrics)
+        state.info.update(info)
+        return state
+        
+    def good_agents_policy(self, state):
+        adv_pos = jp.array([state.p_pos[self.env.a_to_i[a]] for a in self.env.adversaries])
+        good_pos = jp.array([state.p_pos[self.env.a_to_i[a]] for a in self.env.good_agents])
+        vecs = good_pos[:,None,:] - adv_pos[None,:,:]
+        vecs = vecs / (jp.sum(vecs**2, axis=2)**(3/2))[:,:,None]
+        move_dir = jp.sum(vecs, axis=1)
+        
+        actions = jp.zeros((move_dir.shape[0], 5))
+        actions = actions.at[:,[2,4]].set(move_dir)
+        actions = actions.at[:,[1,3]].set(-1 * move_dir)
+        actions = jp.where(actions < 0, 0, actions)
+        good_actions = {a: actions[i] for i, a in enumerate(self.env.good_agents)}
+        return good_actions
+
+    def step(self, state: State, action: jax.Array) -> State:
+        """Run one timestep of the environment's dynamics."""
+        key, key_s = jax.random.split(state.info["mpe_key"], 2)
+        
+        # Generate action dict for adversaries and good agents
+        actions = {agent: action[i] for i, agent in enumerate(self.env.adversaries)}
+        actions.update(self.good_agents_policy(state.pipeline_state))
+        
+        # Step internal environment
+        obs, mpe_state, rewards, dones, infos = self.env.step(key_s, state.pipeline_state, actions)
+
+        # Process obs into our format
+        obs = self.get_obs(mpe_state, obs)
+        
+        # Set trajectory id to differentiate between episodes
+        if "steps" in state.info.keys():
+            seed = state.info["seed"] + jp.where(state.info["steps"], 0, 1)
+        else:
+            seed = state.info["seed"]
+        info = {"seed": seed, "mpe_key": key}
+        state.info.update(info)
+        
+        reward, _ = jp.zeros(2)
+        return state.replace(
+            pipeline_state=mpe_state, obs=obs, reward=reward, done=list(dones.values())[0].astype(jp.float32)
+        )


### PR DESCRIPTION
Draft PR. Putting this up for now so we can integrate this later. These environment wrappers (for MPE simple and tag) and training scripts were created by Chirayu Nimonkar and Shlok Shah, and I've created this PR on behalf of them with their permission.

Environments are in a good state, but need to integrate training script into the main JaxGCRL library (ideally we merge in clean_JaxGCRL in a way that's satisfying to the users). A direct integration with if statements and more flags is straightforward, but I hesitate to add complexity into the codebase (single-agent environment users will see more complexity from MARL which they won't use).
- We can of course just keep a separate MARL training file (either in cleanJaxGCRL or in main JaxGCRL) but this code duplication is prone to divergence when we need to update files.

For now, anyone that wants to use the MPE environments and train them can just use this branch and use the corresponding training file with cleanJaxGCRL.