### PR TITLE
Fix dockerfile & cusolver dependency

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -11,8 +11,8 @@ RUN apt-get update && apt-get install -y \
     mesa-utils \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy the environment file
-COPY environment.yml .
+# Copy environment and project definition files first
+COPY environment.yml pyproject.toml* ./
 
 # Create the Conda environment
 RUN conda env create -f environment.yml

--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,7 @@ dependencies:
     - mujoco-mjx==3.2.7
     - stack-data==0.6.3
     - nvidia-cufft-cu12==11.2.0.44
-    - nvidia-cusolver-cu12==11.6.0.99
+    - nvidia-cusolver-cu12>=11.7.3.90
     - nvidia-cuda-cupti-cu12==12.4.99
     - tyro==0.9.16
     - wandb_osh==1.2.2


### PR DESCRIPTION
When I was trying to set up the Dockerfile in the project, I encountered two errors:

1. The `pyproject.toml` is not included in the copy along `environment.yml`, hence the environment creation fails
2. The `nvidia-cusolver-cu12` dependency in the `environment.yml` does not match the version specified in `pyproject.toml`

This PR fixes these two problems.