### PR TITLE
Fix command syntax in Quick Start section

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ pip install jaxgcrl -f https://storage.googleapis.com/jax-releases/jax_cuda_rele
 
 To verify the installation, run a test experiment:
 ```bash
-jaxgcrl crl --env ant
+jaxgcrl --env ant crl
 ```
 
 The `jaxgcrl` command is equivalent to invoking `python run.py` with the same arguments


### PR DESCRIPTION
Using the original command `jaxgcrl crl --env ant`, I would get the following error:

```
$ jaxgcrl crl --env ant
Gym has been unmaintained since 2022 and does not support NumPy 2.0 amongst other critical functionality.
Please upgrade to Gymnasium, the maintained drop-in replacement of Gym, or contact the authors of your software and request that they upgrade.
Users of this version of Gym should be able to simply replace 'import gym' with 'import gymnasium as gym' in the vast majority of cases.
See the migration guide at https://gymnasium.farama.org/introduction/migration_guide/ for additional information.
╭─ Required options ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Missing from JaxGCRL/.venv/bin/jaxgcrl:                                                                                                                       │
│     --env {ant,ant_random_start,ant_ball,ant_push,humanoid,reacher,cheetah,pusher_easy,pusher_hard,pusher_reacher,pusher2,arm_reach,arm_grasp,arm_push_easy,  │
│     arm_push_hard,arm_binpick_easy,arm_binpick_hard,ant_ball_maze,ant_u_maze,ant_big_maze,ant_hardest_maze,humanoid_u_maze,humanoid_big_maze,                 │
│     humanoid_hardest_maze,simple_u_maze,simple_big_maze,simple_hardest_maze}                                                                                  │
│         environment to use (required)                                                                                                                         │
│ ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── │
│ For full helptext, run:                                                                                                                                       │
│     JaxGCRL/.venv/bin/jaxgcrl --help                                                                                                                          │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

Switching to `jaxgcrl --env ant crl` fixed this for me.