### PR TITLE
Fix crl actor loss numerical instability

### DIFF
--- a/jaxgcrl/agents/crl/losses.py
+++ b/jaxgcrl/agents/crl/losses.py
@@ -45,7 +45,7 @@ def update_actor_and_alpha(config, networks, transitions, training_state, key):
         x_ts = means + stds * jax.random.normal(key, shape=means.shape, dtype=means.dtype)
         action = nn.tanh(x_ts)
         log_prob = jax.scipy.stats.norm.logpdf(x_ts, loc=means, scale=stds)
-        log_prob -= jnp.log((1 - jnp.square(action)) + 1e-6)
+        log_prob -= 2 * (jnp.log(2.0) - x_ts - nn.softplus(-2.0 * x_ts))
         log_prob = log_prob.sum(-1)  # dimension = B
 
         sa_encoder_params, g_encoder_params = (


### PR DESCRIPTION
While training larger networks, I observed instability issues that may have been caused by a certain computation in the actor loss. This PR improves the numerical stability of the calculation, which appears to mitigate those issues.